### PR TITLE
Fix issue causing <C-w>x to close all windows instead of one.

### DIFF
--- a/action_cmds.py
+++ b/action_cmds.py
@@ -150,7 +150,7 @@ class VintageousOrigamiClose(VintageousOrigamiBase):
 
 
 @plugins.register(keys=[('<C-w>X', (modes.NORMAL,))])
-class VintageousOrigamiClose(VintageousOrigamiBase):
+class VintageousOrigamiCloseAll(VintageousOrigamiBase):
     def translate(self, state):
         return {
             'action': 'close_all',


### PR DESCRIPTION
When I installed the latest version I found that <C-w>x (Single window close) would actually close all windows instead of just the current window.

The cause: It appears that the "VintageousOrigamiClose" class name was used when defining the action for both the single window close and all window close. As a result the 2nd class definition is used in both bindings.

I have renamed the 2nd class to VintageousOrigamiCloseAll and this has resolved the issue
